### PR TITLE
Support $XDG_CONFIG_HOME

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,8 +80,11 @@ In the 3rd form, list current bookmark.
 * `-h`                           display this help and exit
 
 ## Variables
+The location of the bookmarks list file depends on the envionment's configuration. The file is searched in the following order:
 
-Bookmark list are stored in `~/.cdbookmark` file. This file name can be changed by `CD_BOOKMARK_FILE` variable.
+1. `$CD_BOOKMARK_FILE` -  if it is set. This has highest precedence. Thus you can set this to override to custom location.
+1. `$XDG_CONFIG_HOME/cd-bookmarks/bookmarks` - if the directory `cd-bookmarks/` exist. Note that `$XDG_CONFIG_HOME` defaults to `$HOME/.config`
+1. `$HOME/.cdbookmark` - fall back to old default $HOME/.cdbookmark
 
 
 ## Examples

--- a/cd-bookmark
+++ b/cd-bookmark
@@ -17,8 +17,18 @@
 #    or: cd-bookmark [-l]
 #
 
+function _cdbookmark_get_config_file() {
+  if  ! [ -z ${CD_BOOKMARK_FILE+x} ]; then
+    echo "$CD_BOOKMARK_FILE"
+  elif [ -d ${XDG_CONFIG_HOME:-$HOME/.config}/cd-bookmark ]; then
+    echo "${XDG_CONFIG_HOME:-$HOME/.config}/cd-bookmark/bookmarks"
+  else
+    echo "${HOME}/.cdbookmark"
+  fi
+}
+
 typeset -r SCRIPT_NAME="cd-bookmark"
-typeset -r BOOKMARK_FILE="${CD_BOOKMARK_FILE:-${HOME}/.cdbookmark}"
+typeset -r BOOKMARK_FILE="$(_cdbookmark_get_config_file)"
 
 function _cdbookmark_print_usage() {
     cat << EOF


### PR DESCRIPTION
Backwards compatible change that supports storing the bookmarks in
`$XDG_CONFIG_HOME/cd-bookmarks`.

1. If the user as set the previously existing `$CD_BOOKMARK_FILE`, this is always overriding.
1. If the user has created/moved the directory/file `$XDG_CONFIG_HOME/cd-bookmarks/(bookmarks)`, use this
1. Else fall back to old default `$HOME/.cdbookmark`

Thus $XDG_CONFIG_HOME is opt-in for those who want. This logic can be changed in a couple of releases to migrate away from $HOME/.cdbookmark.

Tested on zsh `5.8` on macOS.

Fixes #3