### PR TITLE
Add delete command -d

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ In the 3rd form, list current bookmark.
 * `-a` <var>[BOOKMARK\_ID]</var>  add current directory to bookmark<br />
                                 with no BOOKMARK\_ID, automatically use free ID number as BOOKMARK\_ID
 * `-c` <var>BOOKMARK\_ID</var>   change directory which is identified by BOOKMARK\_ID
+* `-d` <var>BOOKMARK\_ID</var>   delete directory which is identified by BOOKMARK\_ID
 * `-l`                           list bookmark
 * `-e`                           edit bookmark file
 * `-p` <var>BOOKMARK\_ID</var>   display bookmark real path for BOOKMARK\_ID
@@ -119,5 +120,8 @@ work|/home/mollifier/work
 # To edit bookmark, run cd-bookmark with -e option.
 % cd-bookmark -e
 # Open bookmark file with $EDITOR (vim, emacs, etc.), so you can edit bookmark.
+
+# To delete a bookmark, run cd-bookmark with -d option.
+% cd-bookmark -d work
 ```
 

--- a/_cd-bookmark
+++ b/_cd-bookmark
@@ -20,6 +20,7 @@ declare -a opts args
 args=(
   '(:)-a[add current directory to bookmark]:new_bookmark_id:_cd-bookmark_current_directory_name'
   '-c[change directory which is identified by BOOKMARK_ID]:bookmark_id:->bookmark_id_or_path'
+  '-d[delete directory which is identified by BOOKMARK_ID]:bookmark_id:->bookmark_id_or_path'
   '-l[list bookmark]'
   '-e[edit bookmark file]'
   '-p[display bookmark real path for BOOKMARK_ID]:bookmark_id:_cd-bookmark_bookmark_id'
@@ -82,4 +83,3 @@ return $ret
 # sh-basic-offset: 2
 # End:
 # vim: ft=zsh sw=2 ts=2 et
-

--- a/cd-bookmark
+++ b/cd-bookmark
@@ -51,6 +51,10 @@ function _cdbookmark_print_error() {
   echo "Try \`-h' option for more information." 1>&2
 }
 
+function _cdbookmark_escape_id() {
+  echo $1 | sed -e 's/[^a-zA-Z0-9<>]/\\&/g'
+}
+
 function _cdbookmark_delete_bookmark() {
   local bookmark_id="$1"
   local bookmark_dir="$(_cdbookmark_get_bookmark $bookmark_id)"
@@ -60,7 +64,7 @@ function _cdbookmark_delete_bookmark() {
     return 4
   fi
 
-  local escaped_id="$(echo $bookmark_id | sed -e 's/[^a-zA-Z0-9<>]/\\&/g')"
+  local escaped_id="$(_cdbookmark_escape_id $1)"
   # To be compatiable with both GNU sed and the old BSD sed that macOS uses, need to set and inplace backup extension and then remove the file.
   # Reference: https://unix.stackexchange.com/a/131940/19909
   sed -i.bak -e "/^${escaped_id}|/d" "$BOOKMARK_FILE" && rm "$BOOKMARK_FILE.bak"
@@ -84,7 +88,7 @@ function _cdbookmark_list_bookmark_id() {
 }
 
 function _cdbookmark_get_bookmark() {
-  local escaped_id="$(echo $1 | sed -e 's/[^a-zA-Z0-9<>]/\\&/g')"
+  local escaped_id="$(_cdbookmark_escape_id $1)"
   cat "$BOOKMARK_FILE" | grep -E "^${escaped_id}\\|" | cut -d '|' -f 2 | head -n 1
 }
 

--- a/cd-bookmark
+++ b/cd-bookmark
@@ -38,6 +38,7 @@ For example if 'cd-bookmark work' command will change current directory to '~/wo
   -a [BOOKMARK_ID]   add current directory to bookmark
                      with no BOOKMARK_ID, automatically use free ID number as BOOKMARK_ID
   -c BOOKMARK_ID     change directory which is identified by BOOKMARK_ID
+  -d BOOKMARK_ID     delete directory which is identified by BOOKMARK_ID
   -l                 list bookmark
   -e                 edit bookmark file
   -p BOOKMARK_ID     display bookmark real path for BOOKMARK_ID
@@ -48,6 +49,21 @@ EOF
 function _cdbookmark_print_error() {
   echo "$SCRIPT_NAME: $@" 1>&2
   echo "Try \`-h' option for more information." 1>&2
+}
+
+function _cdbookmark_delete_bookmark() {
+  local bookmark_id="$1"
+  local bookmark_dir="$(_cdbookmark_get_bookmark $bookmark_id)"
+
+  if [ -z "$bookmark_dir" ]; then
+    _cdbookmark_print_error "$bookmark_id is not in bookmark"
+    return 4
+  fi
+
+  local escaped_id="$(echo $bookmark_id | sed -e 's/[^a-zA-Z0-9<>]/\\&/g')"
+  # To be compatiable with both GNU sed and the old BSD sed that macOS uses, need to set and inplace backup extension and then remove the file.
+  # Reference: https://unix.stackexchange.com/a/131940/19909
+  sed -i.bak -e "/^${escaped_id}|/d" "$BOOKMARK_FILE" && rm "$BOOKMARK_FILE.bak"
 }
 
 function _cdbookmark_edit_bookmark() {
@@ -145,7 +161,7 @@ function _cdbookmark_main() {
   local bookmark_id=""
 
   local option OPTARG OPTIND
-  while getopts ':ac:lep:h' option; do
+  while getopts ':ac:d:lep:h' option; do
     case $option in
       a)
         mode="add"
@@ -153,6 +169,10 @@ function _cdbookmark_main() {
       c)
         bookmark_id="$OPTARG"
         mode="cd"
+        ;;
+      d)
+        bookmark_id="$OPTARG"
+        mode="delete"
         ;;
       l)
         mode="list"
@@ -207,6 +227,9 @@ function _cdbookmark_main() {
       ;;
     cd)
       _cdbookmark_cd_to_bookmark "$bookmark_id"
+      ;;
+    delete)
+      _cdbookmark_delete_bookmark "$bookmark_id"
       ;;
     list)
       _cdbookmark_list_bookmark

--- a/cd-bookmark
+++ b/cd-bookmark
@@ -46,8 +46,8 @@ EOF
 }
 
 function _cdbookmark_print_error() {
-    echo "$SCRIPT_NAME: $@" 1>&2
-    echo "Try \`-h' option for more information." 1>&2
+  echo "$SCRIPT_NAME: $@" 1>&2
+  echo "Try \`-h' option for more information." 1>&2
 }
 
 function _cdbookmark_edit_bookmark() {


### PR DESCRIPTION
The missing piece for this shell program: easily delete bookmarkas as well without having to being faced with all bookmarks with the -e edit command.

When one know the BOOKMARK_ID, it should be as easy as
```console
    $ cd-bookmark -d BOOKMAK_ID
```
to remove it!

Tested on zsh `5.8` on macOS.

Fixes #5
