### PR TITLE
Add minimal bash support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # cd-bookmark
 
 ## Synopsis
-zsh plugin to bookmark directories to cd.
+zsh and bash plugin to bookmark directories to cd.
 
 Inspired by [mokemokechicken post](http://qiita.com/mokemokechicken/items/69af0db3e2cd27c1c467) and shell script in the post.
 
@@ -45,6 +45,12 @@ e.g.
 
 ```
 alias cdb='cd-bookmark'
+```
+
+#### Bash
+For bash users, put this in your shell initialization file (typically `$HOME/.bashrc`):
+```
+source path/to/dir/cd-bookmark/cd-bookmark
 ```
 
 ## Usage

--- a/cd-bookmark
+++ b/cd-bookmark
@@ -226,10 +226,44 @@ function _cdbookmark_main() {
   esac
 }
 
+function _cdbookmarks_bash_completions() {
+  if [ "${#COMP_WORDS[@]}" = "2" ]; then
+    local word_list=(-a -c -d -l -e -p -h)
+    COMPREPLY=($(compgen -W "${word_list[*]}" -- "${COMP_WORDS[1]}"))
+  elif [ "${#COMP_WORDS[@]}" = "3" ] && [[ "${COMP_WORDS[1]}" =~ ^-[acdp]$ ]]; then
+    local comp_word="${COMP_WORDS[2]}"
+
+    if [[ "${COMP_WORDS[1]}" = -c ]] && [[ "$comp_word" == */* ]]; then
+      local strip_bookmark_id="${comp_word%%/*}"
+      local dir_path="${comp_word#*/}"
+      local bookmark_dir="$(_cdbookmark_get_bookmark $strip_bookmark_id)"
+
+      if [ -n "$bookmark_dir" ]; then
+        bookmark_dir="${bookmark_dir}/${dir_path}"
+        local word_list=$(ls -d "${bookmark_dir}"*/ 2>/dev/null | \
+                          sed -e "s|${bookmark_dir}||" -e 's|/$||' -e "s|^|${comp_word}|")
+        COMPREPLY=($(compgen -W "${word_list[*]}" -- "${comp_word}"))
+      fi
+    else
+      local word_list="$(_cdbookmark_list_bookmark_id)"
+      COMPREPLY=($(compgen -W "${word_list[*]}" -- "${comp_word}"))
+    fi
+  fi
+}
+
 #set -o xtrace
 #set -o verbose
 
-_cdbookmark_main "$@"
+if [ -n "$ZSH_VERSION" ]; then
+  # zsh entry point (executed as function from $(autoload -Uz))
+  _cdbookmark_main "$@"
+else
+  # bash entry point (executed as a sourced function)
+  function cd-bookmark() {
+    _cdbookmark_main "$@"
+  }
+  complete -F _cdbookmarks_bash_completions cd-bookmark
+fi
 
 #set +o xtrace
 #set +o verbose


### PR DESCRIPTION
This PR adds support for bash, that works along-side (an unaffecting) the zsh support. Completion for bash is added as well, including relative path completion (`$ cd-bookmark -c BOOKMARKID/path<tab>`)!

This patch was tested on zsh `5.8` and bash `5.1.8` on macOS and it works with both shells.

This is a minimal support patch. I can understand if you don't want to merge this PR as-is, as maybe you would like to structure it differently. In that case, let's use this PR as a start of the conversation.

Otherwise, this PR does add working bash support without compromising zsh support. I've encountered no issues so far.